### PR TITLE
add support for overriding date string formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,30 @@ public View getView(int position, View convertView, ViewGroup parent) {
 }
 ```
 
+## Customize month names and days of week
+CaldroidFragment can be extended to override the default month name + year and day of week formatting used in the month header and week day column headers:
+```java
+public static class CustomCaldroidFragment extends CaldroidFragment {
+	/*
+	 * Use natural case week day names (default is upper case). 
+	 */
+	@Override
+	protected String formatDayOfWeek(DateTime dayOfWeek) {
+		return dayOfWeek.format("WWW", Locale.getDefault());
+	}
+	
+	/*
+	 * Use natural case year/month format, e.g. 2013/August (default is 
+	 * "AUGUST 2013")
+	 */
+	@Override
+	protected String formatMonthAndYear(DateTime monthAndYear) {
+		return monthAndYear.getYear() + "/" + 
+			monthAndYear.format("MMMM", Locale.getDefault());
+	}
+}
+```
+This can also be used to override the string formatting for languages other than English where the formats returned by Date4j are not correct for displaying in a wall calendar like Caldroid.
 
 Basic Structure
 ===============

--- a/library/src/com/roomorama/caldroid/CaldroidFragment.java
+++ b/library/src/com/roomorama/caldroid/CaldroidFragment.java
@@ -867,9 +867,7 @@ public class CaldroidFragment extends DialogFragment {
 
 		// Refresh title view
 		monthTitleTextView
-				.setText(new DateTime(year, month, 1, 0, 0, 0, 0).format(
-						"MMMM", Locale.getDefault()).toUpperCase()
-						+ " " + year);
+				.setText(formatMonthAndYear(new DateTime(year, month, 1, 0, 0, 0, 0)));
 
 		// Refresh the date grid views
 		for (CaldroidGridAdapter adapter : datePagerAdapters) {
@@ -1175,7 +1173,7 @@ public class CaldroidFragment extends DialogFragment {
 	/**
 	 * To display the week day title
 	 * 
-	 * @return "SUN, MON, TUE, WED, THU, FRI, SAT"
+	 * @return e.g. "SUN, MON, TUE, WED, THU, FRI, SAT"
 	 */
 	private ArrayList<String> getDaysOfWeek() {
 		ArrayList<String> list = new ArrayList<String>();
@@ -1185,11 +1183,40 @@ public class CaldroidFragment extends DialogFragment {
 		DateTime nextDay = sunday.plusDays(startDayOfWeek - SUNDAY);
 
 		for (int i = 0; i < 7; i++) {
-			list.add(nextDay.format("WWW", Locale.getDefault()).toUpperCase());
+			list.add(formatDayOfWeek(nextDay));
 			nextDay = nextDay.plusDays(1);
 		}
 
 		return list;
+	}
+	
+	/**
+	 * Override to specify custom day of week abbreviation format for the day of week
+	 * column headers. The default implementation returns the three-character abbreviation 
+	 * of the weekday according to the current locale raised to upper case.
+	 * @param dayOfWeek The day of week to get localized column header for (other fields in 
+	 * the DateTime should be ignored)
+	 * @return The localized abbreviation for the day of week specified by dayOfWeek.
+	 * @author vsin
+	 */
+	protected String formatDayOfWeek(DateTime dayOfWeek) {
+		return dayOfWeek.format("WWW", Locale.getDefault()).toUpperCase();
+	}
+	
+	/**
+	 * Override to specify custom month and year format for display in the month header at top 
+	 * of the calendar. The default implementation returns the full month name according to 
+	 * the current locale raised to upper case and concatenated with a space and the current 
+	 * year as integer.
+	 * @param monthAndYear The month and year to get localized header for (other fields in the 
+	 * DateTime should be ignored)
+	 * @return The localized combination of month and year specified by monthAndYear.
+	 * @author vsin
+	 */
+	protected String formatMonthAndYear(DateTime monthAndYear) {
+		return monthAndYear.format(
+				"MMMM", Locale.getDefault()).toUpperCase()
+				+ " " + monthAndYear.getYear();
 	}
 
 	/**


### PR DESCRIPTION
I was using Caldroid, and it's pretty awesome. But I ran into problems when localizing to Finnish. As soon as I change my phone language to Finnish, some localization assumptions made by Caldroid fail (more detailed explanation below.) To allow fixing, I made it so that CaldroidFragment can be subclassed to manually specify the string formats for the month header and the week day column headers, by insulating the formatting code from in-line to two `protected` methods. Code-wise, it's pretty trivial, and no existing functionality has been altered in any way. But it's probably a must-have requirement to anyone wishing to correctly localize Caldroid.

<br>
#### In detail

So what is the localization assumption that fails? It's essentially that by simply changing the locale you get correctly localized strings for a wall calendar from a standard date formatting implementation designed for expressing individual dates in writing. 

The problem is hard to demonstrate in English, as for English this _is_ a valid assumption. The standard date string format is something like "24 November 2013" or "D MMMM YYYY". Then in Englsih, you can get the name of the month suitable for a _wall calendar_ like Caldroid simply using Date4J's DateTime.format("MMMM"). But in languages unlike English, that make a heavy use of [declension](https://en.wikipedia.org/wiki/Declension), the name of the month in the standard date string format like "D MMMM YYYY" is not necessarily declined in the same noun case as is correct for wall calendars. In Finnish, for example, 2013-11-24 would be "24. marraskuuta 2013", yielding the [partitive case](https://en.wikipedia.org/wiki/Finnish_noun_cases) "<em>m</em>arraskuu<em>ta</em>" for DateTime.format("MMMM"). But a wall calendar should definitely use the nominative case form "<em>M</em>arraskuu" for the name of the month. Note the end of word and letter case; looks like a minute difference, but is actually not.

The other misassumption is that DateTime.format("WWW") returns sensible values. This is actually a bug with Date4J. With "WWW", it returns three-letter week day name abbreviations for every language regardless of locale:

``` java
    else if(WWW.equals(aCurrentToken)){
      int weekday = aDateTime.getWeekDay();
      result = firstThreeChars(fullWeekday(weekday));
    }
```

But Finnish (and many other languages) use two-letter week day name abbreviations ("ma", "ti", "ke" ...), _never_ three-letter ones like English ("Mon", "Tue," "Wed" ...). With a Finnish locale I get "maa", "tii", "kes" ... which is actually so bad that a native speaker could have hard time figuring out what is it even supposed to mean.

It seems the most straightforward fix is to subclass CaldroidFragment and explicitly specify month and week day names for each localized language in my app's private resources. There are anyway only 12 + 7 strings to specify (each month name and each week name) for the languages I am localizing for. The pull request only makes introducing custom month and week day formatting possible; it does ''not'' try to fix the problems described above because they are very specific to each and every language. One way forward in more universal regard could be to investigate how the platform Calendar app gets the right month and weekday strings, because it has them already correctly at least with Finnish as phone language.
