### PR TITLE
fix month name display like platform Calendar app

### DIFF
--- a/library/src/com/roomorama/caldroid/CaldroidFragment.java
+++ b/library/src/com/roomorama/caldroid/CaldroidFragment.java
@@ -5,7 +5,6 @@ import hirondelle.date4j.DateTime;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;


### PR DESCRIPTION
See roomorama/Caldroid#77. 

While the week day name abbreviation problem has been fixed, the month name display error still remains (when phone language is Finnish.) By inspecting the platform [Calendar app source code](https://github.com/android/platform_packages_apps_calendar) I saw how the platform app gets the month name right. This pull request uses [`android.text.format.DateUtils`](http://developer.android.com/reference/android/text/format/DateUtils.html) to get the month name in correct format, like the platform calendar. The month name is now displayed correctly with at least Finnish, Swedish, English, French or German as phone language. Tested on Android 4.0.4 and 2.0.1 phones.
