### PR TITLE
Update today variable when refreshView() is called

### DIFF
--- a/library/src/com/roomorama/caldroid/CaldroidFragment.java
+++ b/library/src/com/roomorama/caldroid/CaldroidFragment.java
@@ -931,6 +931,9 @@ public class CaldroidFragment extends DialogFragment {
 
 			// Reset extra data
 			adapter.setExtraData(extraData);
+			
+			// Update today variable
+			adapter.updateToday();
 
 			// Refresh view
 			adapter.notifyDataSetChanged();

--- a/library/src/com/roomorama/caldroid/CaldroidGridAdapter.java
+++ b/library/src/com/roomorama/caldroid/CaldroidGridAdapter.java
@@ -174,6 +174,10 @@ public class CaldroidGridAdapter extends BaseAdapter {
 		this.datetimeList = CalendarHelper.getFullWeeks(this.month, this.year,
 				startDayOfWeek, sixWeeksInCalendar);
 	}
+	
+	public void updateToday() {
+		today = CalendarHelper.convertDateToDateTime(new Date());		
+	}
 
 	protected DateTime getToday() {
 		if (today == null) {


### PR DESCRIPTION
I noticed that when I called CaldroidFragment.refreshView(), and it was a new day, it did not change the background color / drawable for the date cell for the new day.  So I added an `updateToday()` function in `CaldroidGridAdapter` that is called when `CaldroidFragment.refreshView()` is called.

I have a BroadcastReceiver in my project that is called at the start of each day, and I call refreshView() in it, so now the calendar automatically updates the background of the cell for the new day.
