### PR TITLE
Disallowing launching of multiple instances of the dialog fragment.

### DIFF
--- a/caldroid/src/main/java/com/roomorama/caldroid/CaldroidFragment.java
+++ b/caldroid/src/main/java/com/roomorama/caldroid/CaldroidFragment.java
@@ -1445,6 +1445,12 @@ public class CaldroidFragment extends DialogFragment {
 			dateInMonthsList.addAll(currentAdapter.getDatetimeList());
 		}
 
+    @Override
+    public void show(FragmentManager manager, String tag) {
+      if (manager.findFragmentByTag(tag) == null) {
+        super.show(manager, tag);
+      }
+    }
 	}
 
 


### PR DESCRIPTION
By checking if the DialogFragment is already launched, we can avoid launching multiple instances.
