### PR TITLE
Added posibility of using selectors as backgrounds for specific dates

### DIFF
--- a/caldroid/src/main/java/com/roomorama/caldroid/CaldroidGridAdapter.java
+++ b/caldroid/src/main/java/com/roomorama/caldroid/CaldroidGridAdapter.java
@@ -220,6 +220,14 @@ public class CaldroidGridAdapter extends BaseAdapter {
         }
     }
 
+    View.OnLayoutChangeListener onLayoutChangeListener = new View.OnLayoutChangeListener() {
+        @Override
+        public void onLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom) {
+            v.setSelected(true);
+            v.removeOnLayoutChangeListener(this);
+        }
+    };
+
     /**
      * Customize colors of text and background based on states of the cell
      * (disabled, active, selected, etc)
@@ -280,6 +288,7 @@ public class CaldroidGridAdapter extends BaseAdapter {
             }
 
             cellView.setTextColor(CaldroidFragment.selectedTextColor);
+            cellView.addOnLayoutChangeListener(onLayoutChangeListener);
         } else {
             shouldResetSelectedView = true;
         }


### PR DESCRIPTION
If you try to use a selector as a background for specific dates in order to get a special background when that date is selected, you'll see that it's not possible. First I tried by using cellView.setSelected(true) but this doesn't help since android has it's own bug that removes that state before the view is drawn, more info here: http://stackoverflow.com/questions/12545302/gridview-adapter-getview-does-not-set-selected-state-properly