### PR TITLE
move onCaldroidViewCreated callback to onViewCreated

### DIFF
--- a/caldroid/src/main/java/com/roomorama/caldroid/CaldroidFragment.java
+++ b/caldroid/src/main/java/com/roomorama/caldroid/CaldroidFragment.java
@@ -5,6 +5,7 @@ import android.app.Dialog;
 import android.content.res.Configuration;
 import android.graphics.Color;
 import android.os.Bundle;
+import android.support.annotation.Nullable;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
@@ -1170,16 +1171,21 @@ public class CaldroidFragment extends DialogFragment {
         // Refresh view
         refreshView();
 
-        // Inform client that all views are created and not null
-        // Client should perform customization for buttons and textviews here
-        if (caldroidListener != null) {
-            caldroidListener.onCaldroidViewCreated();
-        }
-
         return view;
     }
 
-    /**
+	@Override
+	public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+		super.onViewCreated(view, savedInstanceState);
+
+		// Inform client that all views are created and not null
+		// Client should perform customization for buttons and textviews here
+		if (caldroidListener != null) {
+			caldroidListener.onCaldroidViewCreated();
+		}
+	}
+
+	/**
      * This method can be used to provide different gridview.
      *
      * @return


### PR DESCRIPTION
I've moved `onCaldroidViewCreated` callback to a fragment's `onViewCreated` in order to allow more low-level view manipulations like this:
```java
@Override
public void onCaldroidViewCreated() {
	// hide calendar view header
	caldroidFragment.getView().findViewById(R.id.calendar_title_view).setVisibility(View.GONE);
}
```