### PR TITLE
customize cell layouts / background resources

### DIFF
--- a/caldroid/src/main/java/com/roomorama/caldroid/CaldroidFragment.java
+++ b/caldroid/src/main/java/com/roomorama/caldroid/CaldroidFragment.java
@@ -145,6 +145,11 @@ public class CaldroidFragment extends DialogFragment {
     public final static String SIX_WEEKS_IN_CALENDAR = "sixWeeksInCalendar";
     public final static String ENABLE_CLICK_ON_DISABLED_DATES = "enableClickOnDisabledDates";
     public final static String SQUARE_TEXT_VIEW_CELL = "squareTextViewCell";
+	public final static String DEFAULT_DATE_CELL_BACKGROUND = "defaultBackground";
+	public final static String CURRENT_DATE_CELL_BACKGROUND = "currentBackground";
+	public final static String SQUARE_CELL_LAYOUT = "squareCellLayout";
+	public final static String NORMAL_CELL_LAYOUT = "normalCellLayout";
+	public final static String WEEK_DAY_CELL_LAYOUT = "weekDayCellLayout";
 
     /**
      * For internal use
@@ -153,6 +158,7 @@ public class CaldroidFragment extends DialogFragment {
     public final static String _MAX_DATE_TIME = "_maxDateTime";
     public final static String _BACKGROUND_FOR_DATETIME_MAP = "_backgroundForDateTimeMap";
     public final static String _TEXT_COLOR_FOR_DATETIME_MAP = "_textColorForDateTimeMap";
+	public final static String _CUSTOM_RESOURCES_MAP = "_customResourcesMap";
 
     /**
      * Initial data
@@ -185,7 +191,9 @@ public class CaldroidFragment extends DialogFragment {
      * textColorForDateMap holds color for text for each date
      */
     protected HashMap<DateTime, Integer> textColorForDateTimeMap = new HashMap<DateTime, Integer>();
-    ;
+
+
+	protected HashMap<String, Integer> customResourcesMap = new HashMap<>();
 
     /**
      * First column of calendar is Sunday
@@ -251,8 +259,11 @@ public class CaldroidFragment extends DialogFragment {
      * provide custom adapter here
      */
     public WeekdayArrayAdapter getNewWeekdayAdapter() {
+		Integer layoutId = customResourcesMap.get(WEEK_DAY_CELL_LAYOUT);
+		if (layoutId == null || layoutId == 0)
+			layoutId = R.layout.weekday_textview;
         return new WeekdayArrayAdapter(
-                getActivity(), android.R.layout.simple_list_item_1,
+                getActivity(), layoutId, android.R.layout.simple_list_item_1,
                 getDaysOfWeek());
     }
 
@@ -337,14 +348,13 @@ public class CaldroidFragment extends DialogFragment {
         caldroidData.put(_MIN_DATE_TIME, minDateTime);
         caldroidData.put(_MAX_DATE_TIME, maxDateTime);
         caldroidData.put(START_DAY_OF_WEEK, Integer.valueOf(startDayOfWeek));
-        caldroidData.put(SIX_WEEKS_IN_CALENDAR,
-                Boolean.valueOf(sixWeeksInCalendar));
+        caldroidData.put(SIX_WEEKS_IN_CALENDAR, Boolean.valueOf(sixWeeksInCalendar));
         caldroidData.put(SQUARE_TEXT_VIEW_CELL, squareTextViewCell);
 
         // For internal use
-        caldroidData
-                .put(_BACKGROUND_FOR_DATETIME_MAP, backgroundForDateTimeMap);
+        caldroidData.put(_BACKGROUND_FOR_DATETIME_MAP, backgroundForDateTimeMap);
         caldroidData.put(_TEXT_COLOR_FOR_DATETIME_MAP, textColorForDateTimeMap);
+		caldroidData.put(_CUSTOM_RESOURCES_MAP, customResourcesMap);
 
         return caldroidData;
     }
@@ -432,6 +442,10 @@ public class CaldroidFragment extends DialogFragment {
     public void setTextColorForDateTime(int textColorRes, DateTime dateTime) {
         textColorForDateTimeMap.put(dateTime, Integer.valueOf(textColorRes));
     }
+
+	public void setCustomResource(String resourceKey, int resourceId) {
+		customResourcesMap.put(resourceKey, resourceId);
+	}
 
     /**
      * Get current saved sates of the Caldroid. Useful for handling rotation.
@@ -1061,7 +1075,6 @@ public class CaldroidFragment extends DialogFragment {
                 maxDateTime = CalendarHelper.getDateTimeFromString(
                         maxDateTimeString, null);
             }
-
         }
         if (month == -1 || year == -1) {
             DateTime dateTime = DateTime.today(TimeZone.getDefault());

--- a/caldroid/src/main/java/com/roomorama/caldroid/CaldroidGridAdapter.java
+++ b/caldroid/src/main/java/com/roomorama/caldroid/CaldroidGridAdapter.java
@@ -189,8 +189,7 @@ public class CaldroidGridAdapter extends BaseAdapter {
     }
 
     @SuppressWarnings("unchecked")
-    protected void setCustomResources(DateTime dateTime, View backgroundView,
-                                      TextView textView) {
+    protected void setCustomResources(DateTime dateTime, View backgroundView, TextView textView) {
         // Set custom background resource
         HashMap<DateTime, Integer> backgroundForDateTimeMap = (HashMap<DateTime, Integer>) caldroidData
                 .get(CaldroidFragment._BACKGROUND_FOR_DATETIME_MAP);
@@ -200,8 +199,7 @@ public class CaldroidGridAdapter extends BaseAdapter {
 
             // Set it
             if (backgroundResource != null) {
-                backgroundView.setBackgroundResource(backgroundResource
-                        .intValue());
+                backgroundView.setBackgroundResource(backgroundResource);
             }
         }
 
@@ -214,11 +212,20 @@ public class CaldroidGridAdapter extends BaseAdapter {
 
             // Set it
             if (textColorResource != null) {
-                textView.setTextColor(resources.getColor(textColorResource
-                        .intValue()));
+                textView.setTextColor(resources.getColor(textColorResource));
             }
         }
     }
+
+	private int getCustomizedResourceId(String key, int defaultResourceId) {
+		HashMap<String, Integer> customResourcesMap = (HashMap<String, Integer>) caldroidData.get(CaldroidFragment._CUSTOM_RESOURCES_MAP);
+		if (customResourcesMap != null) {
+			Integer resourceId = customResourcesMap.get(key);
+			if (resourceId != null && resourceId != 0)
+				return resourceId;
+		}
+		return defaultResourceId;
+	}
 
     /**
      * Customize colors of text and background based on states of the cell
@@ -275,8 +282,7 @@ public class CaldroidGridAdapter extends BaseAdapter {
             if (CaldroidFragment.selectedBackgroundDrawable != -1) {
                 cellView.setBackgroundResource(CaldroidFragment.selectedBackgroundDrawable);
             } else {
-                cellView.setBackgroundColor(resources
-                        .getColor(R.color.caldroid_sky_blue));
+                cellView.setBackgroundColor(resources.getColor(R.color.caldroid_sky_blue));
             }
 
             cellView.setTextColor(CaldroidFragment.selectedTextColor);
@@ -287,9 +293,9 @@ public class CaldroidGridAdapter extends BaseAdapter {
         if (shouldResetDiabledView && shouldResetSelectedView) {
             // Customize for today
             if (dateTime.equals(getToday())) {
-                cellView.setBackgroundResource(R.drawable.red_border);
+                cellView.setBackgroundResource(getCustomizedResourceId(CaldroidFragment.CURRENT_DATE_CELL_BACKGROUND, R.drawable.red_border));
             } else {
-                cellView.setBackgroundResource(R.drawable.cell_bg);
+                cellView.setBackgroundResource(getCustomizedResourceId(CaldroidFragment.DEFAULT_DATE_CELL_BACKGROUND, R.drawable.cell_bg));
             }
         }
 
@@ -330,9 +336,9 @@ public class CaldroidGridAdapter extends BaseAdapter {
         // For reuse
         if (convertView == null) {
             if (squareTextViewCell) {
-                cellView = (TextView) inflater.inflate(R.layout.square_date_cell, null);
+                cellView = (TextView) inflater.inflate(getCustomizedResourceId(CaldroidFragment.SQUARE_CELL_LAYOUT, R.layout.square_date_cell), null);
             } else {
-                cellView = (TextView) inflater.inflate(R.layout.normal_date_cell, null);
+                cellView = (TextView) inflater.inflate(getCustomizedResourceId(CaldroidFragment.NORMAL_CELL_LAYOUT, R.layout.normal_date_cell), null);
             }
         }
 

--- a/caldroid/src/main/java/com/roomorama/caldroid/WeekdayArrayAdapter.java
+++ b/caldroid/src/main/java/com/roomorama/caldroid/WeekdayArrayAdapter.java
@@ -19,9 +19,11 @@ import java.util.List;
 public class WeekdayArrayAdapter extends ArrayAdapter<String> {
     public static int textColor = Color.LTGRAY;
 
-    public WeekdayArrayAdapter(Context context, int textViewResourceId,
-                               List<String> objects) {
+	int layoutId;
+
+    public WeekdayArrayAdapter(Context context, int layoutId, int textViewResourceId,List<String> objects) {
         super(context, textViewResourceId, objects);
+		this.layoutId = layoutId;
     }
 
     // To prevent cell highlighted when clicked
@@ -39,7 +41,7 @@ public class WeekdayArrayAdapter extends ArrayAdapter<String> {
     public View getView(int position, View convertView, ViewGroup parent) {
         // To customize text size and color
         LayoutInflater inflater = (LayoutInflater) getContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-        TextView textView = (TextView) inflater.inflate(R.layout.weekday_textview, null);
+        TextView textView = (TextView) inflater.inflate(layoutId, null);
 
         // Set content
         String item = getItem(position);


### PR DESCRIPTION
These changes allows you to adjust looks & feel of calendar view that meets you project's guidelines

current date background drawable resource:
```java
calendarFragment.setCustomResource(CaldroidFragment.CURRENT_DATE_CELL_BACKGROUND, R.drawable.calendar_default_cell);
```
regular date cell background drawable resource:
```java
calendarFragment.setCustomResource(CaldroidFragment.DEFAULT_DATE_CELL_BACKGROUND, R.drawable.calendar_default_cell);
```
custom date cells layout:
```java
calendarFragment.setCustomResource(CaldroidFragment.SQUARE_CELL_LAYOUT, R.layout.calendar_date_cell);
calendarFragment.setCustomResource(CaldroidFragment.NORMAL_CELL_LAYOUT, R.layout.calendar_date_cell);
```
week days header cells layout:
```java
calendarFragment.setCustomResource(CaldroidFragment.WEEK_DAY_CELL_LAYOUT, R.layout.calendar_weekday_cell);
```