### PR TITLE
Padding, horizontalSpacing and verticalSpacing now can be customized.

### DIFF
--- a/caldroid/src/main/res/layout/date_grid_fragment.xml
+++ b/caldroid/src/main/res/layout/date_grid_fragment.xml
@@ -5,9 +5,6 @@
     android:layout_height="wrap_content"
     android:adjustViewBounds="true"
     android:gravity="center_horizontal"
-    android:horizontalSpacing="1dp"
     android:numColumns="7"
-    android:padding="1dp"
     android:stretchMode="columnWidth"
-    android:verticalSpacing="1dp"
     style="?styleCaldroidGridView" />


### PR DESCRIPTION
Padding, horizontalSpacing and verticalSpacing cannot be customized in styles, because they are overridden in the layout file. These lines are already in the CaldroidDefault theme, so I suggest deleting them.