### PR TITLE
Fix timezone change issue when showing month name (issue #308)

### DIFF
--- a/caldroid/src/main/java/com/roomorama/caldroid/CaldroidFragment.java
+++ b/caldroid/src/main/java/com/roomorama/caldroid/CaldroidFragment.java
@@ -1026,7 +1026,7 @@ public class CaldroidFragment extends DialogFragment {
         // Refresh title view
         firstMonthTime.year = year;
         firstMonthTime.month = month - 1;
-        firstMonthTime.monthDay = 1;
+        firstMonthTime.monthDay = 15;
         long millis = firstMonthTime.toMillis(true);
 
         // This is the method used by the platform Calendar app to get a


### PR DESCRIPTION
The month title show the month name of last month when users timezone change after firstMonthTime is set, I am able to reproduce with the following steps:

1/ Set to Amsterdam timezone
2/ Open the calendar
3/ Switch to Minsk timezone
3/ Open the calendar