### PR TITLE
Replaced HashMap method arguments and return values with Map.

### DIFF
--- a/caldroid/src/main/java/com/roomorama/caldroid/CaldroidFragment.java
+++ b/caldroid/src/main/java/com/roomorama/caldroid/CaldroidFragment.java
@@ -13,8 +13,12 @@ import android.support.v4.app.FragmentManager;
 import android.support.v4.view.ViewPager.OnPageChangeListener;
 import android.text.format.DateUtils;
 import android.text.format.Time;
-import android.view.*;
+import android.view.ContextThemeWrapper;
+import android.view.LayoutInflater;
+import android.view.View;
 import android.view.View.OnClickListener;
+import android.view.ViewGroup;
+import android.view.Window;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemClickListener;
 import android.widget.AdapterView.OnItemLongClickListener;
@@ -35,6 +39,7 @@ import java.util.Formatter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.TimeZone;
 
 import hirondelle.date4j.DateTime;
@@ -169,22 +174,22 @@ public class CaldroidFragment extends DialogFragment {
     /**
      * caldroidData belongs to Caldroid
      */
-    protected HashMap<String, Object> caldroidData = new HashMap<String, Object>();
+    protected Map<String, Object> caldroidData = new HashMap<>();
 
     /**
      * extraData belongs to client
      */
-    protected HashMap<String, Object> extraData = new HashMap<String, Object>();
+    protected Map<String, Object> extraData = new HashMap<>();
 
     /**
      * backgroundForDateMap holds background resource for each date
      */
-    protected HashMap<DateTime, Integer> backgroundForDateTimeMap = new HashMap<DateTime, Integer>();
+    protected Map<DateTime, Integer> backgroundForDateTimeMap = new HashMap<>();
 
     /**
      * textColorForDateMap holds color for text for each date
      */
-    protected HashMap<DateTime, Integer> textColorForDateTimeMap = new HashMap<DateTime, Integer>();
+    protected Map<DateTime, Integer> textColorForDateTimeMap = new HashMap<>();
     ;
 
     /**
@@ -301,11 +306,11 @@ public class CaldroidFragment extends DialogFragment {
     /*
      * For client to access background and text color maps
      */
-    public HashMap<DateTime, Integer> getBackgroundForDateTimeMap() {
+    public Map<DateTime, Integer> getBackgroundForDateTimeMap() {
         return backgroundForDateTimeMap;
     }
 
-    public HashMap<DateTime, Integer> getTextColorForDateTimeMap() {
+    public Map<DateTime, Integer> getTextColorForDateTimeMap() {
         return textColorForDateTimeMap;
     }
 
@@ -346,7 +351,7 @@ public class CaldroidFragment extends DialogFragment {
      *
      * @return
      */
-    public HashMap<String, Object> getCaldroidData() {
+    public Map<String, Object> getCaldroidData() {
         caldroidData.clear();
         caldroidData.put(DISABLE_DATES, disableDates);
         caldroidData.put(SELECTED_DATES, selectedDates);
@@ -372,7 +377,7 @@ public class CaldroidFragment extends DialogFragment {
      *
      * @return
      */
-    public HashMap<String, Object> getExtraData() {
+    public Map<String, Object> getExtraData() {
         return extraData;
     }
 
@@ -381,7 +386,7 @@ public class CaldroidFragment extends DialogFragment {
      *
      * @param extraData
      */
-    public void setExtraData(HashMap<String, Object> extraData) {
+    public void setExtraData(Map<String, Object> extraData) {
         this.extraData = extraData;
     }
 
@@ -389,7 +394,7 @@ public class CaldroidFragment extends DialogFragment {
      * Set backgroundForDateMap
      */
     public void setBackgroundResourceForDates(
-            HashMap<Date, Integer> backgroundForDateMap) {
+            Map<Date, Integer> backgroundForDateMap) {
         if (backgroundForDateMap == null || backgroundForDateMap.size() == 0) {
             return;
         }
@@ -414,7 +419,7 @@ public class CaldroidFragment extends DialogFragment {
     }
 
     public void setBackgroundResourceForDateTimes(
-            HashMap<DateTime, Integer> backgroundForDateTimeMap) {
+            Map<DateTime, Integer> backgroundForDateTimeMap) {
         this.backgroundForDateTimeMap.putAll(backgroundForDateTimeMap);
     }
 
@@ -450,7 +455,7 @@ public class CaldroidFragment extends DialogFragment {
      *
      * @return
      */
-    public void setTextColorForDates(HashMap<Date, Integer> textColorForDateMap) {
+    public void setTextColorForDates(Map<Date, Integer> textColorForDateMap) {
         if (textColorForDateMap == null || textColorForDateMap.size() == 0) {
             return;
         }
@@ -473,7 +478,7 @@ public class CaldroidFragment extends DialogFragment {
     }
 
     public void setTextColorForDateTimes(
-            HashMap<DateTime, Integer> textColorForDateTimeMap) {
+            Map<DateTime, Integer> textColorForDateTimeMap) {
         this.textColorForDateTimeMap.putAll(textColorForDateTimeMap);
     }
 

--- a/caldroid/src/main/java/com/roomorama/caldroid/CaldroidGridAdapter.java
+++ b/caldroid/src/main/java/com/roomorama/caldroid/CaldroidGridAdapter.java
@@ -17,6 +17,7 @@ import com.caldroid.R;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Map;
 
 import hirondelle.date4j.DateTime;
 
@@ -35,8 +36,8 @@ public class CaldroidGridAdapter extends BaseAdapter {
 
     // Use internally, to make the search for date faster instead of using
     // indexOf methods on ArrayList
-    protected HashMap<DateTime, Integer> disableDatesMap = new HashMap<>();
-    protected HashMap<DateTime, Integer> selectedDatesMap = new HashMap<>();
+    protected Map<DateTime, Integer> disableDatesMap = new HashMap<>();
+    protected Map<DateTime, Integer> selectedDatesMap = new HashMap<>();
 
     protected DateTime minDateTime;
     protected DateTime maxDateTime;
@@ -53,11 +54,11 @@ public class CaldroidGridAdapter extends BaseAdapter {
     /**
      * caldroidData belongs to Caldroid
      */
-    protected HashMap<String, Object> caldroidData;
+    protected Map<String, Object> caldroidData;
     /**
      * extraData belongs to client
      */
-    protected HashMap<String, Object> extraData;
+    protected Map<String, Object> extraData;
 
 	protected LayoutInflater localInflater;
 
@@ -109,22 +110,22 @@ public class CaldroidGridAdapter extends BaseAdapter {
         return themeResource;
     }
 
-    public HashMap<String, Object> getCaldroidData() {
+    public Map<String, Object> getCaldroidData() {
         return caldroidData;
     }
 
-    public void setCaldroidData(HashMap<String, Object> caldroidData) {
+    public void setCaldroidData(Map<String, Object> caldroidData) {
         this.caldroidData = caldroidData;
 
         // Reset parameters
         populateFromCaldroidData();
     }
 
-    public HashMap<String, Object> getExtraData() {
+    public Map<String, Object> getExtraData() {
         return extraData;
     }
 
-    public void setExtraData(HashMap<String, Object> extraData) {
+    public void setExtraData(Map<String, Object> extraData) {
         this.extraData = extraData;
     }
 
@@ -138,8 +139,8 @@ public class CaldroidGridAdapter extends BaseAdapter {
      * @param extraData
      */
     public CaldroidGridAdapter(Context context, int month, int year,
-                               HashMap<String, Object> caldroidData,
-                               HashMap<String, Object> extraData) {
+                               Map<String, Object> caldroidData,
+                               Map<String, Object> extraData) {
         super();
         this.month = month;
         this.year = year;
@@ -236,7 +237,7 @@ public class CaldroidGridAdapter extends BaseAdapter {
     protected void setCustomResources(DateTime dateTime, View backgroundView,
                                       TextView textView) {
         // Set custom background resource
-        HashMap<DateTime, Integer> backgroundForDateTimeMap = (HashMap<DateTime, Integer>) caldroidData
+        Map<DateTime, Integer> backgroundForDateTimeMap = (Map<DateTime, Integer>) caldroidData
                 .get(CaldroidFragment._BACKGROUND_FOR_DATETIME_MAP);
         if (backgroundForDateTimeMap != null) {
             // Get background resource for the dateTime
@@ -249,7 +250,7 @@ public class CaldroidGridAdapter extends BaseAdapter {
         }
 
         // Set custom text color
-        HashMap<DateTime, Integer> textColorForDateTimeMap = (HashMap<DateTime, Integer>) caldroidData
+        Map<DateTime, Integer> textColorForDateTimeMap = (Map<DateTime, Integer>) caldroidData
                 .get(CaldroidFragment._TEXT_COLOR_FOR_DATETIME_MAP);
         if (textColorForDateTimeMap != null) {
             // Get textColor for the dateTime

--- a/caldroidSampleActivity/src/main/java/com/caldroidsample/CaldroidSampleCustomAdapter.java
+++ b/caldroidSampleActivity/src/main/java/com/caldroidsample/CaldroidSampleCustomAdapter.java
@@ -11,15 +11,15 @@ import android.widget.TextView;
 import com.roomorama.caldroid.CaldroidFragment;
 import com.roomorama.caldroid.CaldroidGridAdapter;
 
-import java.util.HashMap;
+import java.util.Map;
 
 import hirondelle.date4j.DateTime;
 
 public class CaldroidSampleCustomAdapter extends CaldroidGridAdapter {
 
 	public CaldroidSampleCustomAdapter(Context context, int month, int year,
-			HashMap<String, Object> caldroidData,
-			HashMap<String, Object> extraData) {
+			Map<String, Object> caldroidData,
+			Map<String, Object> extraData) {
 		super(context, month, year, caldroidData, extraData);
 	}
 


### PR DESCRIPTION
This change allows alternative implementations of the Map interface (such as android.support.v4.util.ArrayMap) to be used.

The motivation behind wanting to use ArrayMap can be seen in this video: https://youtu.be/ORgucLTtTDI