### PR TITLE
Calendar height bug

### DIFF
--- a/caldroid/src/main/java/com/antonyt/infiniteviewpager/InfiniteViewPager.java
+++ b/caldroid/src/main/java/com/antonyt/infiniteviewpager/InfiniteViewPager.java
@@ -130,6 +130,9 @@ public class InfiniteViewPager extends ViewPager {
 					.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED));
 
 			rowHeight = firstChild.getMeasuredHeight();
+			if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN
+					&& firstChild instanceof GridView)
+				rowHeight += ((GridView)firstChild).getVerticalSpacing();
 		}
 
 		// Calculate height of the calendar


### PR DESCRIPTION
Calendar exact height was calculated without taking into account the GridView attribute _verticalSpacing_, which resulted in _rowHeight_ value being smaller than it should be. Then, we tried to fit a number of rows (5) in too little space, which resulted in the calendar being wrapped in a scroll.

See http://developer.android.com/intl/es/reference/android/widget/GridView.html#attr_android:verticalSpacing
