### PR TITLE
Allow setting textAllCaps to change capitalization for month name

### DIFF
--- a/caldroid/src/main/java/com/roomorama/caldroid/CaldroidFragment.java
+++ b/caldroid/src/main/java/com/roomorama/caldroid/CaldroidFragment.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.res.Configuration;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.DialogFragment;
@@ -1043,7 +1044,11 @@ public class CaldroidFragment extends DialogFragment {
         String monthTitle = DateUtils.formatDateRange(getActivity(),
                 monthYearFormatter, millis, millis, MONTH_YEAR_FLAG).toString();
 
-        monthTitleTextView.setText(monthTitle.toUpperCase(Locale.getDefault()));
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
+            monthTitle = monthTitle.toUpperCase(Locale.getDefault());
+        }
+
+        monthTitleTextView.setText(monthTitle);
     }
 
     /**

--- a/caldroid/src/main/res/values/styles.xml
+++ b/caldroid/src/main/res/values/styles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <style name="CaldroidDefault">
         <item name="styleCaldroidViewLayout">@style/CaldroidDefaultCalendarViewLayout</item>
         <item name="styleCaldroidLeftArrow">@style/CaldroidDefaultLeftButton</item>
@@ -40,6 +40,7 @@
         <item name="android:layout_marginTop">3dp</item>
         <item name="android:gravity">center_horizontal</item>
         <item name="android:textSize">21sp</item>
+        <item name="android:textAllCaps" tools:targetApi="ice_cream_sandwich">true</item>
     </style>
 
     <style name="CaldroidDefaultGridView">


### PR DESCRIPTION
This will allow you to set `android:textAllCaps="false"` on the month name style to remove the capitalization. If the device's Android version is too old to support `textAllCaps`, the capitalization is still done in code for backwards compatibility.
