### PR TITLE
DIALOG_TITLE argument is without effect on Marshmallow

### DIFF
--- a/caldroid/src/main/res/values/styles.xml
+++ b/caldroid/src/main/res/values/styles.xml
@@ -9,6 +9,7 @@
         <item name="styleCaldroidNormalCell">@style/CaldroidDefaultNormalCell</item>
         <item name="styleCaldroidSquareCell">@style/CaldroidDefaultSquareCell</item>
         <item name="styleCaldroidWeekdayView">@style/CaldroidDefaultWeekday</item>
+        <item name="android:windowNoTitle">false</item>
     </style>
 
     <style name="CaldroidDefaultCalendarViewLayout">


### PR DESCRIPTION
### Problem:

If you try to set a dialog title for a Caldroid dialog with 

```
    CaldroidFragment f = new CaldroidFragment();
    Bundle args = new Bundle();
    args.putString(DIALOG_TITLE, "My dialog title");
    f.setArguments(args);
```

the title is not shown on Marshmallow devices.
### Reason

The default for windowNoTitle is false for Lollipop and below, but true on Marshmallow. Compare with http://stackoverflow.com/a/32711916/1199911
### Solution

Set windowNotTitle explicitly to false.
