### PR TITLE
Add enable/disable option to wrap content in InfiniteViewPager

### DIFF
--- a/caldroid/src/main/java/com/antonyt/infiniteviewpager/InfiniteViewPager.java
+++ b/caldroid/src/main/java/com/antonyt/infiniteviewpager/InfiniteViewPager.java
@@ -32,6 +32,11 @@ public class InfiniteViewPager extends ViewPager {
 	private boolean enabled = true;
 
 	/**
+	 * Enable wrap content strict adjusting
+	 */
+	private boolean enabledStrictWrapContent = true;
+
+	/**
 	 * A calendar height is not fixed, it may have 4, 5 or 6 rows. Set
 	 * fitAllMonths to true so that the calendar will always have 6 rows
 	 */
@@ -49,6 +54,14 @@ public class InfiniteViewPager extends ViewPager {
 
 	public void setEnabled(boolean enabled) {
 		this.enabled = enabled;
+	}
+
+	public boolean isEnabledStrictWrapContent() {
+		return enabledStrictWrapContent;
+	}
+
+	public void setEnabledStrictWrapContent(boolean enabledStrictWrapContent) {
+		this.enabledStrictWrapContent = enabledStrictWrapContent;
 	}
 
 	public boolean isSixWeeksInCalendar() {
@@ -113,6 +126,10 @@ public class InfiniteViewPager extends ViewPager {
 	@Override
 	protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
 		super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+
+		if(!enabledStrictWrapContent) {
+			return;
+		}
 
 		// Calculate row height
 		int rows = datesInMonth.size() / 7;

--- a/caldroid/src/main/java/com/roomorama/caldroid/CaldroidFragment.java
+++ b/caldroid/src/main/java/com/roomorama/caldroid/CaldroidFragment.java
@@ -147,7 +147,8 @@ public class CaldroidFragment extends DialogFragment {
             SIX_WEEKS_IN_CALENDAR = "sixWeeksInCalendar",
             ENABLE_CLICK_ON_DISABLED_DATES = "enableClickOnDisabledDates",
             SQUARE_TEXT_VIEW_CELL = "squareTextViewCell",
-            THEME_RESOURCE = "themeResource";
+            THEME_RESOURCE = "themeResource",
+            ENABLE_STRICT_WRAP_CONTENT = "enableStrictWrapContent";
 
     /**
      * For internal use
@@ -213,6 +214,12 @@ public class CaldroidFragment extends DialogFragment {
     protected boolean enableSwipe = true;
     protected boolean showNavigationArrows = true;
     protected boolean enableClickOnDisabledDates = false;
+
+
+    /**
+     * Enable strict wrap content for date view pager
+     */
+    protected boolean enableStrictWrapContent = true;
 
     /**
      * To use SquareTextView to display Date cell.By default, it is true,
@@ -531,6 +538,7 @@ public class CaldroidFragment extends DialogFragment {
         bundle.putInt(START_DAY_OF_WEEK, startDayOfWeek);
         bundle.putBoolean(SIX_WEEKS_IN_CALENDAR, sixWeeksInCalendar);
         bundle.putInt(THEME_RESOURCE, themeResource);
+        bundle.putBoolean(ENABLE_STRICT_WRAP_CONTENT, enableStrictWrapContent);
 
         Bundle args = getArguments();
         if (args != null && args.containsKey(SQUARE_TEXT_VIEW_CELL)) {
@@ -861,6 +869,20 @@ public class CaldroidFragment extends DialogFragment {
     }
 
     /**
+     * Enable / Disable strict wrap content logic for cells
+     *
+     * @return
+     */
+    public boolean isEnableStrictWrapContent() {
+        return enableStrictWrapContent;
+    }
+
+    public void setEnableStrictWrapContent(boolean enableStrictWrapContent) {
+        this.enableStrictWrapContent = enableStrictWrapContent;
+        dateViewPager.setEnabledStrictWrapContent(enableStrictWrapContent);
+    }
+
+    /**
      * Enable / Disable swipe to navigate different months
      *
      * @return
@@ -1170,6 +1192,9 @@ public class CaldroidFragment extends DialogFragment {
 
             // Get theme
             themeResource = args.getInt(THEME_RESOURCE, R.style.CaldroidDefault);
+
+            // get enabled strict wrap content
+            enableStrictWrapContent = args.getBoolean(ENABLE_STRICT_WRAP_CONTENT, true);
         }
         if (month == -1 || year == -1) {
             DateTime dateTime = DateTime.today(TimeZone.getDefault());
@@ -1386,12 +1411,15 @@ public class CaldroidFragment extends DialogFragment {
         // height correctly
         dateViewPager.setDatesInMonth(dateInMonthsList);
 
+        dateViewPager.setEnabledStrictWrapContent(enableStrictWrapContent);
+
         // MonthPagerAdapter actually provides 4 real fragments. The
         // InfinitePagerAdapter only recycles fragment provided by this
         // MonthPagerAdapter
         final MonthPagerAdapter pagerAdapter = new MonthPagerAdapter(
                 getChildFragmentManager());
 
+                
         // Provide initial data to the fragments, before they are attached to
         // view.
         fragments = pagerAdapter.getFragments();


### PR DESCRIPTION
If you set new option to false it allows you to make something like this:

```
    <LinearLayout
        android:id="@+id/caldroid_fragment_layout"
        android:layout_width="match_parent"
        android:layout_height="0dp"
        android:layout_weight="1"
        android:orientation="vertical"/>
```

And caldroid cells will be resized to available space in layout.

I can provide small working example if you would like to check.
