### PR TITLE
Reuse old DateGridFragment in adapter

### DIFF
--- a/caldroid/src/main/java/com/roomorama/caldroid/CaldroidFragment.java
+++ b/caldroid/src/main/java/com/roomorama/caldroid/CaldroidFragment.java
@@ -1392,6 +1392,9 @@ public class CaldroidFragment extends DialogFragment {
         final MonthPagerAdapter pagerAdapter = new MonthPagerAdapter(
                 getChildFragmentManager());
 
+        // Use old fragments if possible
+        pagerAdapter.setFragments(fragments);
+
         // Provide initial data to the fragments, before they are attached to
         // view.
         fragments = pagerAdapter.getFragments();


### PR DESCRIPTION
Each time onCreateView called new fragments are created. It would be better to use old fragments from my point of view.

I have strange bug because of it - onCreateView in DateGridFragment is called for old fragments after switching to other view and return back
