### PR TITLE
Add listener callback to allow disabling SwipeRefreshLayout when scrolling ViewPager horizontally

### DIFF
--- a/caldroid/src/main/java/com/roomorama/caldroid/CaldroidFragment.java
+++ b/caldroid/src/main/java/com/roomorama/caldroid/CaldroidFragment.java
@@ -11,6 +11,7 @@ import android.support.annotation.Nullable;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
+import android.support.v4.view.ViewPager;
 import android.support.v4.view.ViewPager.OnPageChangeListener;
 import android.text.format.DateUtils;
 import android.text.format.Time;
@@ -1385,6 +1386,24 @@ public class CaldroidFragment extends DialogFragment {
         // Set the numberOfDaysInMonth to dateViewPager so it can calculate the
         // height correctly
         dateViewPager.setDatesInMonth(dateInMonthsList);
+
+        // Set callback to allow app to disable swiperefresh or other uses
+        dateViewPager.addOnPageChangeListener(new OnPageChangeListener() {
+            @Override
+            public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
+            }
+
+            @Override
+            public void onPageSelected(int position) {
+            }
+
+            @Override
+            public void onPageScrollStateChanged(int state) {
+                if (caldroidListener != null) {
+                    caldroidListener.pagerScrolling(state != ViewPager.SCROLL_STATE_IDLE);
+                }
+            }
+        });
 
         // MonthPagerAdapter actually provides 4 real fragments. The
         // InfinitePagerAdapter only recycles fragment provided by this

--- a/caldroid/src/main/java/com/roomorama/caldroid/CaldroidListener.java
+++ b/caldroid/src/main/java/com/roomorama/caldroid/CaldroidListener.java
@@ -54,4 +54,13 @@ public abstract class CaldroidListener {
     public void onCaldroidViewCreated() {
         // Do nothing
     }
+
+    /**
+     * Inform client that the viewpager is scrolling. Give the app the chance to
+     * disable a swipe refresh layout, or do other checking
+     * @param scrolling
+     */
+    public void pagerScrolling(boolean scrolling) {
+
+    }
 }

--- a/caldroidSampleActivity/src/main/java/com/caldroidsample/CaldroidSampleActivity.java
+++ b/caldroidSampleActivity/src/main/java/com/caldroidsample/CaldroidSampleActivity.java
@@ -5,6 +5,7 @@ import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
 import android.support.v4.app.FragmentTransaction;
+import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -21,8 +22,9 @@ import java.util.Calendar;
 import java.util.Date;
 
 @SuppressLint("SimpleDateFormat")
-public class CaldroidSampleActivity extends AppCompatActivity {
+public class CaldroidSampleActivity extends AppCompatActivity implements SwipeRefreshLayout.OnRefreshListener {
     private boolean undo = false;
+    private SwipeRefreshLayout refresh;
     private CaldroidFragment caldroidFragment;
     private CaldroidFragment dialogCaldroidFragment;
 
@@ -54,6 +56,9 @@ public class CaldroidSampleActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main);
 
         final SimpleDateFormat formatter = new SimpleDateFormat("dd MMM yyyy");
+
+        refresh = (SwipeRefreshLayout) findViewById(R.id.swipe_refresh);
+        refresh.setOnRefreshListener(this);
 
         // Setup caldroid fragment
         // **** If you want normal CaldroidFragment, use below line ****
@@ -132,6 +137,10 @@ public class CaldroidSampleActivity extends AppCompatActivity {
                 }
             }
 
+            @Override
+            public void pagerScrolling(boolean scrolling) {
+                refresh.setEnabled(!scrolling);
+            }
         };
 
         // Setup Caldroid
@@ -277,4 +286,8 @@ public class CaldroidSampleActivity extends AppCompatActivity {
         }
     }
 
+    @Override
+    public void onRefresh() {
+        refresh.setRefreshing(false);
+    }
 }

--- a/caldroidSampleActivity/src/main/res/layout/activity_main.xml
+++ b/caldroidSampleActivity/src/main/res/layout/activity_main.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView
+<android.support.v4.widget.SwipeRefreshLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/swipe_refresh"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+<ScrollView
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -44,3 +49,5 @@
 
     </LinearLayout>
 </ScrollView>
+</android.support.v4.widget.SwipeRefreshLayout>
+


### PR DESCRIPTION
This adds a callback to the listener to inform the app that the viewpager is scrolling. This allows the app to disable a swiperefresh during scroll. This fix is discussed here: http://stackoverflow.com/questions/25978462/swiperefreshlayout-viewpager-limit-horizontal-scroll-only
Fixes #420 
