### PR TITLE
API level 7 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It's very easy to customize look and feel of Caldroid using your own theme, than
 
 Caldroid is fully localized. You can customize start day of the week for different countries. By default calendar start on Sunday.
 
-Caldroid can be used with Android 2.2 and above. It is extracted from [official Roomorama application](https://play.google.com/store/apps/details?id=com.roomorama)
+Caldroid can be used with Android 2.1 and above. It is extracted from [official Roomorama application](https://play.google.com/store/apps/details?id=com.roomorama)
 
 <img src="https://raw.github.com/roomorama/Caldroid/master/screenshot/1.png" width="270" style="margin-right:10px;">
 <img src="https://raw.github.com/roomorama/Caldroid/master/screenshot/dark.png" width="270">
@@ -36,7 +36,7 @@ Features
 ========
 
 ##Flexible setup: can be embedded or shown as dialog
-If you support Android 2.2 and above, you can embed caldroid fragment in your activity with below code:
+If you support Android 2.1 and above, you can embed caldroid fragment in your activity with below code:
 
 ``` java
 CaldroidFragment caldroidFragment = new CaldroidFragment();

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.3.1'
     }
 }
 

--- a/caldroid/build.gradle
+++ b/caldroid/build.gradle
@@ -1,17 +1,17 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 24
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
-        minSdkVersion 8
-        targetSdkVersion 22
+        minSdkVersion 7
+        targetSdkVersion 24
     }
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:22.2.0'
+    compile 'com.android.support:support-v4:24.1.1'
     compile 'com.darwinsys:hirondelle-date4j:1.5.1'
 }
 

--- a/caldroidSampleActivity/build.gradle
+++ b/caldroidSampleActivity/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 24
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.caldroidsample"
-        minSdkVersion 8
-        targetSdkVersion 22
+        minSdkVersion 7
+        targetSdkVersion 24
     }
 
     buildTypes {
@@ -20,6 +20,6 @@ android {
 
 dependencies {
     compile project(':caldroid')
-    compile 'com.android.support:support-v4:22.2.0'
-    compile 'com.android.support:appcompat-v7:22.2.0'
+    compile 'com.android.support:support-v4:24.1.1'
+    compile 'com.android.support:appcompat-v7:24.1.1'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Feb 05 14:08:01 CST 2015
+#Sun Apr 23 04:37:43 KST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
I noticed it can support API level 7 too.

![image](https://cloud.githubusercontent.com/assets/13031505/25307647/85e7f6a6-27df-11e7-9637-c8ad7cea9d35.png)

Above image demonstrates that it's executable on emulator level 7.

Please accept this request and release new version of library as soon as possible!