### PR TITLE
Fix crash with androidx appcompat 1.1.0

### DIFF
--- a/caldroid/src/main/java/com/roomorama/caldroid/CaldroidFragment.java
+++ b/caldroid/src/main/java/com/roomorama/caldroid/CaldroidFragment.java
@@ -31,7 +31,6 @@ import com.antonyt.infiniteviewpager.InfinitePagerAdapter;
 import com.antonyt.infiniteviewpager.InfiniteViewPager;
 import com.caldroid.R;
 
-import java.lang.reflect.Field;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -1603,22 +1602,5 @@ public class CaldroidFragment extends DialogFragment {
             dateInMonthsList.addAll(currentAdapter.getDatetimeList());
         }
 
-    }
-
-    @Override
-    public void onDetach() {
-        super.onDetach();
-
-        try {
-            Field childFragmentManager = Fragment.class
-                    .getDeclaredField("mChildFragmentManager");
-            childFragmentManager.setAccessible(true);
-            childFragmentManager.set(this, null);
-
-        } catch (NoSuchFieldException e) {
-            throw new RuntimeException(e);
-        } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
     }
 }


### PR DESCRIPTION
This prevents a crash with appcompat 1.1.0.

Exception thrown:
```
E/AndroidRuntime: FATAL EXCEPTION: main
    Process: ***, PID: 5575
    java.lang.RuntimeException: Unable to destroy activity {***/***.MainActivity}: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean androidx.fragment.app.FragmentManagerImpl.isDestroyed()' on a null object reference
        at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:4458)
        at android.app.ActivityThread.handleDestroyActivity(ActivityThread.java:4476)
        at android.app.ActivityThread.handleRelaunchActivityInner(ActivityThread.java:4760)
        at android.app.ActivityThread.handleRelaunchActivity(ActivityThread.java:4693)
        at android.app.servertransaction.ActivityRelaunchItem.execute(ActivityRelaunchItem.java:69)
        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:108)
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:68)
        at android.app.ClientTransactionHandler.executeTransaction(ClientTransactionHandler.java:55)
        at android.app.ActivityThread.handleRelaunchActivityLocally(ActivityThread.java:4743)
        at android.app.ActivityThread.access$3200(ActivityThread.java:199)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1818)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loop(Looper.java:193)
        at android.app.ActivityThread.main(ActivityThread.java:6669)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
     Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean androidx.fragment.app.FragmentManagerImpl.isDestroyed()' on a null object reference
        at androidx.fragment.app.Fragment.performDetach(Fragment.java:2844)
        at androidx.fragment.app.FragmentManagerImpl.moveToState(FragmentManagerImpl.java:1033)
        at androidx.fragment.app.FragmentManagerImpl.moveFragmentToExpectedState(FragmentManagerImpl.java:1237)
        at androidx.fragment.app.FragmentManagerImpl.moveToState(FragmentManagerImpl.java:1302)
        at androidx.fragment.app.FragmentManagerImpl.dispatchStateChange(FragmentManagerImpl.java:2655)
        at androidx.fragment.app.FragmentManagerImpl.dispatchDestroy(FragmentManagerImpl.java:2640)
        at androidx.fragment.app.FragmentController.dispatchDestroy(FragmentController.java:329)
        at androidx.fragment.app.FragmentActivity.onDestroy(FragmentActivity.java:366)
        at androidx.appcompat.app.AppCompatActivity.onDestroy(AppCompatActivity.java:233)
        at ***.MainActivity.onDestroy(MainActivity.kt:376)
        at android.app.Activity.performDestroy(Activity.java:7395)
        at android.app.Instrumentation.callActivityOnDestroy(Instrumentation.java:1306)
        at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:4443)
```

Associated google tracker issue: https://issuetracker.google.com/issues/135764330